### PR TITLE
chore(ci): introduce vale as linter for documentation

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -1,0 +1,21 @@
+name: vale
+on: [pull_request]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  vale:
+    name: Prose linter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: errata-ai/vale-action@reviewdog
+        with:
+          version: 3.4.2
+          filter_mode: diff_context
+          fail_on_error: true
+          reporter: github-pr-review
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,5 @@
+StylesPath = .github/styles
+MinAlertLevel = suggestion
+
+[README.md]
+BasedOnStyles = Vale

--- a/README.md
+++ b/README.md
@@ -31,23 +31,20 @@ to use.
 
 ### Usage
 
-To fetch all available fixtures, one can run
+Fetch all available fixtures.
 
 ```elixir
 fixtures = UOF.API.Sports.fixtures
 ```
 
-Given the above list of fixtures, we can easily get a quick idea of the nature
-of the currently available fixtures.
-
-For example, we can count how many fixtures are available
+Given a list fixtures, count how many of them there are.
 
 ```elixir
 Enum.count(fixtures)
 # => 51591
 ```
 
-Or inspect a random fixture
+Or inspect a random fixture from the list.
 
 ```elixir
 fixture = Enum.random(fixtures)


### PR DESCRIPTION
### Description

Introduce [Vale](https://github.com/errata-ai/vale) to run code-like linting on documentation.

For now, just a very basic configuration to avoid spelling mistakes.