### PR TITLE
build: update gh token used in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        persist-credentials: false
 
       - uses: cycjimmy/semantic-release-action@v4.1.0
         with:
@@ -25,4 +26,4 @@ jobs:
           branches: |
             [ 'main' ]
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_HEX }}


### PR DESCRIPTION
### Description

Use a Personal Access Token (PAT) in the release workflow. [Otherwise, releases won't trigger the publish workflow](https://github.com/semantic-release/github?tab=readme-ov-file#github-authentication).