### PR TITLE
fix: data loss in polymorphic Sports.fixture/1 responses

### DIFF
--- a/lib/uof/api/booking.ex
+++ b/lib/uof/api/booking.ex
@@ -11,7 +11,6 @@ defmodule UOF.API.Booking do
   `liveodds` helpers in `UOF.API.Sports.Fixtures` (e.g.
   `UOF.API.Sports.Fixtures.bookable/1`).
   """
-  alias UOF.Schemas.Common.Response
   alias UOF.API.Utils.HTTP
 
   @doc """
@@ -19,6 +18,6 @@ defmodule UOF.API.Booking do
   """
   def book(sport_event) do
     endpoint = ["liveodds", "booking-calendar", "events", sport_event, "book"]
-    HTTP.post(Response, endpoint)
+    HTTP.post(endpoint)
   end
 end

--- a/lib/uof/api/custom_bet.ex
+++ b/lib/uof/api/custom_bet.ex
@@ -16,7 +16,7 @@ defmodule UOF.API.CustomBet do
   def available_selections(fixture) do
     endpoint = ["custombet", fixture, "available_selections"]
 
-    HTTP.get(UOF.Schemas.API.CustomBet.AvailableSelections, endpoint)
+    HTTP.get(endpoint)
   end
 
   @doc """
@@ -26,14 +26,11 @@ defmodule UOF.API.CustomBet do
   def calculate(selections, filter \\ false) do
     body = selections_to_xml(selections, filter)
     endpoint = calculate_endpoint(filter)
-    HTTP.post(calculate_schema(filter), endpoint, body)
+    HTTP.post(endpoint, body)
   end
 
   defp calculate_endpoint(true), do: ["custombet", "calculate-filter"]
   defp calculate_endpoint(false), do: ["custombet", "calculate"]
-
-  defp calculate_schema(true), do: UOF.Schemas.API.CustomBet.FilteredCalculationResponse
-  defp calculate_schema(false), do: UOF.Schemas.API.CustomBet.CalculationResponse
 
   defp selections_to_xml(selections, false) do
     selections

--- a/lib/uof/api/descriptions.ex
+++ b/lib/uof/api/descriptions.ex
@@ -20,7 +20,7 @@ defmodule UOF.API.Descriptions do
     # TO-DO: Optional mappings
     endpoint = ["descriptions", lang, "markets.xml"]
 
-    HTTP.get(UOF.Schemas.API.Descriptions.MarketDescriptions, endpoint)
+    HTTP.get(endpoint)
   end
 
   @doc """
@@ -30,7 +30,7 @@ defmodule UOF.API.Descriptions do
   def match_statuses(lang \\ "en") do
     endpoint = ["descriptions", lang, "match_status.xml"]
 
-    HTTP.get(UOF.Schemas.API.Descriptions.MatchStatusDescriptions, endpoint)
+    HTTP.get(endpoint)
   end
 
   @doc """
@@ -39,7 +39,7 @@ defmodule UOF.API.Descriptions do
   def betstop_reasons do
     endpoint = ["descriptions", "betstop_reasons.xml"]
 
-    HTTP.get(UOF.Schemas.API.Descriptions.BetstopReasonsDescriptions, endpoint)
+    HTTP.get(endpoint)
   end
 
   @doc """
@@ -48,7 +48,7 @@ defmodule UOF.API.Descriptions do
   def betting_statuses do
     endpoint = ["descriptions", "betting_status.xml"]
 
-    HTTP.get(UOF.Schemas.API.Descriptions.BettingStatusDescriptions, endpoint)
+    HTTP.get(endpoint)
   end
 
   @doc """
@@ -57,7 +57,7 @@ defmodule UOF.API.Descriptions do
   def variants(lang \\ "en") do
     endpoint = ["descriptions", lang, "variants.xml"]
 
-    HTTP.get(UOF.Schemas.API.Descriptions.VariantDescriptions, endpoint)
+    HTTP.get(endpoint)
   end
 
   @doc """
@@ -66,7 +66,7 @@ defmodule UOF.API.Descriptions do
   def producers do
     endpoint = ["descriptions", "producers.xml"]
 
-    HTTP.get(UOF.Schemas.API.Descriptions.Producers, endpoint)
+    HTTP.get(endpoint)
   end
 
   @doc """
@@ -75,6 +75,6 @@ defmodule UOF.API.Descriptions do
   def void_reasons do
     endpoint = ["descriptions", "void_reasons.xml"]
 
-    HTTP.get(UOF.Schemas.API.Descriptions.VoidReasonsDescriptions, endpoint)
+    HTTP.get(endpoint)
   end
 end

--- a/lib/uof/api/probability.ex
+++ b/lib/uof/api/probability.ex
@@ -18,7 +18,7 @@ defmodule UOF.API.Probability do
   """
   def probabilities(fixture) do
     endpoint = ["probabilities", fixture]
-    HTTP.get(UOF.Schemas.API.Probability.Cashout, endpoint)
+    HTTP.get(endpoint)
   end
 
   @doc """
@@ -26,7 +26,7 @@ defmodule UOF.API.Probability do
   """
   def probabilities(fixture, market) do
     endpoint = ["probabilities", fixture, market]
-    HTTP.get(UOF.Schemas.API.Probability.Cashout, endpoint)
+    HTTP.get(endpoint)
   end
 
   @doc """
@@ -34,6 +34,6 @@ defmodule UOF.API.Probability do
   """
   def probabilities(fixture, market, specifier) do
     endpoint = ["probabilities", fixture, market, specifier]
-    HTTP.get(UOF.Schemas.API.Probability.Cashout, endpoint)
+    HTTP.get(endpoint)
   end
 end

--- a/lib/uof/api/recovery.ex
+++ b/lib/uof/api/recovery.ex
@@ -14,7 +14,6 @@ defmodule UOF.API.Recovery do
     * `:node_id` — target a specific feed node
     * `:after` — only on `recover/2`; milliseconds since the Unix epoch (UTC)
   """
-  alias UOF.Schemas.Common.Response
   alias UOF.API.Utils.HTTP
 
   @doc """
@@ -25,7 +24,7 @@ defmodule UOF.API.Recovery do
   """
   def recover(product, opts \\ []) do
     endpoint = [product, "recovery", "initiate_request"]
-    HTTP.post(Response, endpoint, "", Keyword.take(opts, [:after, :request_id, :node_id]))
+    HTTP.post(endpoint, "", Keyword.take(opts, [:after, :request_id, :node_id]))
   end
 
   @doc """
@@ -33,7 +32,7 @@ defmodule UOF.API.Recovery do
   """
   def recover_event(product, sport_event, opts \\ []) do
     endpoint = [product, "odds", "events", sport_event, "initiate_request"]
-    HTTP.post(Response, endpoint, "", Keyword.take(opts, [:request_id, :node_id]))
+    HTTP.post(endpoint, "", Keyword.take(opts, [:request_id, :node_id]))
   end
 
   @doc """
@@ -42,6 +41,6 @@ defmodule UOF.API.Recovery do
   """
   def recover_stateful_messages(product, sport_event, opts \\ []) do
     endpoint = [product, "stateful_messages", "events", sport_event, "initiate_request"]
-    HTTP.post(Response, endpoint, "", Keyword.take(opts, [:request_id, :node_id]))
+    HTTP.post(endpoint, "", Keyword.take(opts, [:request_id, :node_id]))
   end
 end

--- a/lib/uof/api/sports.ex
+++ b/lib/uof/api/sports.ex
@@ -24,7 +24,7 @@ defmodule UOF.API.Sports do
     # TO-DO: handle codds fixture (eg. codds:competition_group:77739)
     endpoint = ["sports", lang, "sport_events", fixture, "fixture.xml"]
 
-    HTTP.get(UOF.Schemas.API.Sports.FixturesEndpoint, endpoint)
+    HTTP.get(endpoint)
   end
 
   @doc """
@@ -33,7 +33,7 @@ defmodule UOF.API.Sports do
   def schedule(date, lang \\ "en") do
     endpoint = ["sports", lang, "schedules", date, "schedule.xml"]
 
-    HTTP.get(UOF.Schemas.API.Sports.ScheduleEndpoint, endpoint)
+    HTTP.get(endpoint)
   end
 
   @doc """
@@ -42,7 +42,7 @@ defmodule UOF.API.Sports do
   def live_schedule(lang \\ "en") do
     endpoint = ["sports", lang, "schedules", "live", "schedule.xml"]
 
-    HTTP.get(UOF.Schemas.API.Sports.ScheduleEndpoint, endpoint)
+    HTTP.get(endpoint)
   end
 
   @doc """
@@ -51,7 +51,7 @@ defmodule UOF.API.Sports do
   def pre_schedule(start \\ 0, limit \\ 100, lang \\ "en") do
     endpoint = ["sports", lang, "schedules", "pre", "schedule.xml"]
 
-    HTTP.get(UOF.Schemas.API.Sports.ScheduleEndpoint, endpoint, start: start, limit: limit)
+    HTTP.get(endpoint, start: start, limit: limit)
   end
 
   @doc """
@@ -60,7 +60,7 @@ defmodule UOF.API.Sports do
   def tournament_schedule(tournament, lang \\ "en") do
     endpoint = ["sports", lang, "tournaments", tournament, "schedule.xml"]
 
-    HTTP.get(UOF.Schemas.API.Sports.ScheduleEndpoint, endpoint)
+    HTTP.get(endpoint)
   end
 
   @doc """
@@ -70,7 +70,7 @@ defmodule UOF.API.Sports do
     # TO-DO: add support for 'after datetime' and 'sport' filters
     endpoint = ["sports", lang, "fixtures", "changes.xml"]
 
-    HTTP.get(UOF.Schemas.API.Sports.FixtureChangesEndpoint, endpoint)
+    HTTP.get(endpoint)
   end
 
   @doc """
@@ -80,7 +80,7 @@ defmodule UOF.API.Sports do
     # TO-DO: add support for 'after datetime' and 'sport' filters
     endpoint = ["sports", lang, "results", "changes.xml"]
 
-    HTTP.get(UOF.Schemas.API.Sports.ResultChangesEndpoint, endpoint)
+    HTTP.get(endpoint)
   end
 
   ## Sport Event Information
@@ -94,7 +94,7 @@ defmodule UOF.API.Sports do
     # TO-DO: differentiate between match and race summaries
     endpoint = ["sports", lang, "sport_events", fixture, "summary.xml"]
 
-    HTTP.get(UOF.Schemas.API.Sports.MatchSummaryEndpoint, endpoint)
+    HTTP.get(endpoint)
   end
 
   @doc """
@@ -105,7 +105,7 @@ defmodule UOF.API.Sports do
   def timeline(fixture, lang \\ "en") do
     endpoint = ["sports", lang, "sport_events", fixture, "timeline.xml"]
 
-    HTTP.get(UOF.Schemas.API.Sports.MatchTimelineEndpoint, endpoint)
+    HTTP.get(endpoint)
   end
 
   @doc """
@@ -114,7 +114,7 @@ defmodule UOF.API.Sports do
   def sports(lang \\ "en") do
     endpoint = ["sports", lang, "sports.xml"]
 
-    HTTP.get(UOF.Schemas.API.Sports.SportsEndpoint, endpoint)
+    HTTP.get(endpoint)
   end
 
   @doc """
@@ -123,7 +123,7 @@ defmodule UOF.API.Sports do
   def categories(sport, lang \\ "en") do
     endpoint = ["sports", lang, "sports", sport, "categories.xml"]
 
-    HTTP.get(UOF.Schemas.API.Sports.SportCategoriesEndpoint, endpoint)
+    HTTP.get(endpoint)
   end
 
   @doc """
@@ -132,13 +132,13 @@ defmodule UOF.API.Sports do
   def sport_tournaments(sport, lang \\ "en") do
     endpoint = ["sports", lang, "sports", sport, "tournaments.xml"]
 
-    HTTP.get(UOF.Schemas.API.Sports.SportTournamentsEndpoint, endpoint)
+    HTTP.get(endpoint)
   end
 
   def tournaments(lang \\ "en") do
     endpoint = ["sports", lang, "tournaments.xml"]
 
-    HTTP.get(UOF.Schemas.API.Sports.TournamentsEndpoint, endpoint)
+    HTTP.get(endpoint)
   end
 
   @doc """
@@ -150,7 +150,7 @@ defmodule UOF.API.Sports do
 
     # TO-DO: staged tournaments
     # https://docs.betradar.com/display/BD/UOF+-+Formula+1
-    HTTP.get(UOF.Schemas.API.Sports.TournamentInfoEndpoint, endpoint)
+    HTTP.get(endpoint)
   end
 
   @doc """
@@ -159,7 +159,7 @@ defmodule UOF.API.Sports do
   def seasons(tournament, lang \\ "en") do
     endpoint = ["sports", lang, "tournaments", tournament, "seasons.xml"]
 
-    HTTP.get(UOF.Schemas.API.Sports.TournamentSeasons, endpoint)
+    HTTP.get(endpoint)
   end
 
   ## Entity Description
@@ -171,7 +171,7 @@ defmodule UOF.API.Sports do
     # https://docs.betradar.com/display/BD/UOF+-+Player+profile
     endpoint = ["sports", lang, "players", player, "profile.xml"]
 
-    HTTP.get(UOF.Schemas.API.Sports.PlayerProfileEndpoint, endpoint)
+    HTTP.get(endpoint)
   end
 
   @doc """
@@ -181,7 +181,7 @@ defmodule UOF.API.Sports do
     # https://docs.betradar.com/display/BD/UOF+-+Competitors+profile
     endpoint = ["sports", lang, "competitors", competitor, "profile.xml"]
 
-    HTTP.get(UOF.Schemas.API.Sports.CompetitorProfileEndpoint, endpoint)
+    HTTP.get(endpoint)
   end
 
   @doc """
@@ -191,6 +191,6 @@ defmodule UOF.API.Sports do
     # https://docs.betradar.com/display/BD/UOF+-+Venues
     endpoint = ["sports", lang, "venues", venue, "profile.xml"]
 
-    HTTP.get(UOF.Schemas.API.Sports.VenueSummaryEndpoint, endpoint)
+    HTTP.get(endpoint)
   end
 end

--- a/lib/uof/api/users.ex
+++ b/lib/uof/api/users.ex
@@ -11,6 +11,6 @@ defmodule UOF.API.Users do
   def whoami do
     endpoint = ["users", "whoami.xml"]
 
-    HTTP.get(UOF.Schemas.API.Users.BookmakerDetails, endpoint)
+    HTTP.get(endpoint)
   end
 end

--- a/lib/uof/api/utils/http.ex
+++ b/lib/uof/api/utils/http.ex
@@ -1,16 +1,16 @@
 defmodule UOF.API.Utils.HTTP do
   @moduledoc false
 
-  def get(schema, path, params \\ []) do
+  def get(path, params \\ []) do
     client()
     |> Req.get!(url: Enum.join(path, "/"), params: params)
-    |> decode(schema)
+    |> decode()
   end
 
-  def post(schema, path, body \\ "", params \\ []) do
+  def post(path, body \\ "", params \\ []) do
     client()
     |> Req.post!(url: Enum.join(path, "/"), params: params, body: body)
-    |> decode(schema)
+    |> decode()
   end
 
   defp client do
@@ -24,5 +24,9 @@ defmodule UOF.API.Utils.HTTP do
     )
   end
 
-  defp decode(%Req.Response{body: body}, schema), do: UOF.Schemas.XML.decode(body, schema)
+  # Every endpoint is polymorphic on its XML root element (a season request to the
+  # fixture endpoint returns <tournament_info>, any endpoint may return the shared
+  # <response> error envelope), so dispatch on the root via decode/1 rather than
+  # asserting a fixed schema.
+  defp decode(%Req.Response{body: body}), do: UOF.Schemas.XML.decode(body)
 end

--- a/test/uof/api/booking_test.exs
+++ b/test/uof/api/booking_test.exs
@@ -3,9 +3,9 @@ defmodule UOF.API.Booking.Test do
   use Mimic
 
   setup do
-    stub(UOF.API.Utils.HTTP, :post, fn schema, _endpoint ->
+    stub(UOF.API.Utils.HTTP, :post, fn _endpoint ->
       data = File.read!("test/data/booking_response.xml")
-      UOF.Schemas.XML.decode(data, schema)
+      UOF.Schemas.XML.decode(data)
     end)
 
     :ok

--- a/test/uof/api/custom_bet_test.exs
+++ b/test/uof/api/custom_bet_test.exs
@@ -3,14 +3,14 @@ defmodule UOF.API.CustomBet.Test do
   use Mimic
 
   setup do
-    stub(UOF.API.Utils.HTTP, :get, fn schema, _endpoint ->
+    stub(UOF.API.Utils.HTTP, :get, fn _endpoint ->
       data = File.read!("test/data/available_selections.xml")
-      UOF.Schemas.XML.decode(data, schema)
+      UOF.Schemas.XML.decode(data)
     end)
 
-    stub(UOF.API.Utils.HTTP, :post, fn schema, _endpoint, _body ->
+    stub(UOF.API.Utils.HTTP, :post, fn _endpoint, _body ->
       data = File.read!("test/data/custombet_calculation.xml")
-      UOF.Schemas.XML.decode(data, schema)
+      UOF.Schemas.XML.decode(data)
     end)
 
     :ok

--- a/test/uof/api/descriptions_test.exs
+++ b/test/uof/api/descriptions_test.exs
@@ -3,9 +3,9 @@ defmodule UOF.API.Descriptions.Test do
   use Mimic
 
   setup do
-    stub(UOF.API.Utils.HTTP, :get, fn schema, endpoint ->
+    stub(UOF.API.Utils.HTTP, :get, fn endpoint ->
       data = File.read!("test/data/" <> Enum.at(endpoint, -1))
-      UOF.Schemas.XML.decode(data, schema)
+      UOF.Schemas.XML.decode(data)
     end)
 
     :ok

--- a/test/uof/api/probability_test.exs
+++ b/test/uof/api/probability_test.exs
@@ -3,9 +3,9 @@ defmodule UOF.API.Probability.Test do
   use Mimic
 
   setup do
-    stub(UOF.API.Utils.HTTP, :get, fn schema, _endpoint ->
+    stub(UOF.API.Utils.HTTP, :get, fn _endpoint ->
       data = File.read!("test/data/cashout.xml")
-      UOF.Schemas.XML.decode(data, schema)
+      UOF.Schemas.XML.decode(data)
     end)
 
     :ok

--- a/test/uof/api/recovery_test.exs
+++ b/test/uof/api/recovery_test.exs
@@ -3,9 +3,9 @@ defmodule UOF.API.Recovery.Test do
   use Mimic
 
   setup do
-    stub(UOF.API.Utils.HTTP, :post, fn schema, _endpoint, _body, _params ->
+    stub(UOF.API.Utils.HTTP, :post, fn _endpoint, _body, _params ->
       data = File.read!("test/data/recovery_response.xml")
-      UOF.Schemas.XML.decode(data, schema)
+      UOF.Schemas.XML.decode(data)
     end)
 
     :ok

--- a/test/uof/api/sports_test.exs
+++ b/test/uof/api/sports_test.exs
@@ -3,9 +3,14 @@ defmodule UOF.API.Sports.Test do
   use Mimic
 
   setup do
-    stub(UOF.API.Utils.HTTP, :get, fn schema, endpoint ->
+    stub(UOF.API.Utils.HTTP, :get, fn endpoint ->
       {:ok, data} = fetch_mock_data(endpoint)
-      UOF.Schemas.XML.decode(data, schema)
+      UOF.Schemas.XML.decode(data)
+    end)
+
+    stub(UOF.API.Utils.HTTP, :get, fn endpoint, _params ->
+      {:ok, data} = fetch_mock_data(endpoint)
+      UOF.Schemas.XML.decode(data)
     end)
 
     :ok
@@ -145,6 +150,21 @@ defmodule UOF.API.Sports.Test do
     assert reference.value == "11428313"
   end
 
+  # The fixture endpoint is polymorphic: querying a season/tournament id returns
+  # a <tournament_info> document rather than <fixtures_fixture>. Dispatching on
+  # the root element must surface it as a TournamentInfoEndpoint instead of a
+  # hollow FixturesEndpoint.
+  test "fixture/2 on a season id returns the tournament_info document" do
+    stub(UOF.API.Utils.HTTP, :get, fn ["sports", _lang, "sport_events", _id, "fixture.xml"] ->
+      UOF.Schemas.XML.decode(File.read!("test/data/tournament_info.xml"))
+    end)
+
+    assert {:ok, %UOF.Schemas.API.Sports.TournamentInfoEndpoint{} = info} =
+             UOF.API.Sports.fixture("sr:season:101177")
+
+    assert info.tournament.id == "sr:tournament:7"
+  end
+
   test "can parse UOF.API.Sports.fixture_changes/{0, 1} response" do
     {:ok, data} = UOF.API.Sports.fixture_changes()
 
@@ -168,9 +188,9 @@ defmodule UOF.API.Sports.Test do
   test "stream/0 paginates the prematch schedule and aggregates events" do
     page = File.read!("test/data/schedule.xml")
 
-    stub(UOF.API.Utils.HTTP, :get, fn schema, _endpoint, params ->
+    stub(UOF.API.Utils.HTTP, :get, fn _endpoint, params ->
       data = if Keyword.get(params, :start, 0) == 0, do: page, else: "<schedule/>"
-      UOF.Schemas.XML.decode(data, schema)
+      UOF.Schemas.XML.decode(data)
     end)
 
     events = UOF.API.Sports.Fixtures.stream() |> Enum.to_list()

--- a/test/uof/api/users_test.exs
+++ b/test/uof/api/users_test.exs
@@ -3,9 +3,9 @@ defmodule UOF.API.Users.Test do
   use Mimic
 
   setup do
-    stub(UOF.API.Utils.HTTP, :get, fn schema, endpoint ->
+    stub(UOF.API.Utils.HTTP, :get, fn endpoint ->
       data = File.read!("test/data/" <> Enum.at(endpoint, -1))
-      UOF.Schemas.XML.decode(data, schema)
+      UOF.Schemas.XML.decode(data)
     end)
 
     :ok


### PR DESCRIPTION
### Description

`uof_api` forced every HTTP response into a fixed schema via `decode/2` static mode. But the Sportradar endpoints are polymorphic on their XML root element. For example, `fixture.xml` on a season id returns `<tournament_info>`, not `<fixtures_fixture>`.

So `UOF.API.Sports.fixture("sr:season:101177")` was asserting `FixturesEndpoint` and producing a hollow struct instead of the real `TournamentInfoEndpoint`, and error responses were silently mis-decoded across all API calls.