### PR TITLE
feat!: structured error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,9 +169,35 @@ Odds recovery (the recovered messages arrive over the AMQP feed; the HTTP call
 returns an acknowledgement):
 
 ```elixir
-{:ok, _ack} = UOF.API.Recovery.recover("liveodds", request_id: 1, after: 1_700_000_000_000)
-{:ok, _ack} = UOF.API.Recovery.recover_event("liveodds", "sr:match:12345", request_id: 2)
+{:ok, _ack_or_nil} = UOF.API.Recovery.recover("liveodds", request_id: 1, after: 1_700_000_000_000)
+{:ok, _ack_or_nil} = UOF.API.Recovery.recover_event("liveodds", "sr:match:12345", request_id: 2)
 ```
+
+### Error handling
+
+API calls return `{:ok, response}` for every successful HTTP status and
+`{:error, %UOF.API.Error{}}` for HTTP, transport, or XML decoding failures.
+Successful responses without a body return `{:ok, nil}`.
+
+The numeric HTTP status and Sportradar's response code are kept separately:
+
+```elixir
+case UOF.API.Sports.fixture("sr:match:12345") do
+  {:ok, fixture} ->
+    fixture
+
+  {:error, %UOF.API.Error{status: 404, response_code: "NOT_FOUND"} = error} ->
+    error.message
+
+  {:error, %UOF.API.Error{} = error} ->
+    error
+end
+```
+
+When present, response headers and the decoded error body are available through
+`error.headers` and `error.body`. Non-XML bodies such as JSON or CDN-generated
+HTML are preserved. Errors encountered by `UOF.API.Sports.Fixtures.stream/1`
+are raised while the stream is enumerated.
 
 
 ## Contributing

--- a/lib/uof/api/booking.ex
+++ b/lib/uof/api/booking.ex
@@ -5,6 +5,8 @@ defmodule UOF.API.Booking do
   Booking makes a sport event available for live odds. The HTTP response is only
   an acknowledgement (`UOF.Schemas.Common.Response`).
 
+  Functions return `{:ok, response} | {:error, UOF.API.Error.t()}`.
+
   There are no GET endpoints for the booking calendar — booking state is exposed
   on schedule responses via the `liveodds` attribute (`"booked"`, `"bookable"`,
   `"buyable"`, `"not_available"`). Filter a schedule by that state with the

--- a/lib/uof/api/custom_bet.ex
+++ b/lib/uof/api/custom_bet.ex
@@ -6,6 +6,8 @@ defmodule UOF.API.CustomBet do
   calculation as if it was a regular accumulator bet.
 
   CustomBet API is only available for soccer and basketball fixtures.
+
+  Functions return `{:ok, response} | {:error, UOF.API.Error.t()}`.
   """
   alias UOF.API.Utils.HTTP
 

--- a/lib/uof/api/descriptions.ex
+++ b/lib/uof/api/descriptions.ex
@@ -7,7 +7,7 @@ defmodule UOF.API.Descriptions do
   match statuses and betting statuses used in `odds_change` messages, betstop
   reasons, and void reasons used in `bet_settlement` messages.
 
-  Every function returns `{:ok, struct} | {:error, Ecto.Changeset.t()}`, where
+  Every function returns `{:ok, struct} | {:error, UOF.API.Error.t()}`, where
   the struct is an `UOF.Schemas.API.Descriptions.*` embedded schema. Endpoints
   that vary by language take an optional `lang` (ISO code, default `"en"`).
   """

--- a/lib/uof/api/error.ex
+++ b/lib/uof/api/error.ex
@@ -1,0 +1,37 @@
+defmodule UOF.API.Error do
+  @moduledoc """
+  An error returned by the UOF HTTP client.
+
+  `type` distinguishes errors returned by the API from transport and response
+  decoding failures. For HTTP errors, `status` is the numeric HTTP status and
+  `response_code` is the separate code supplied by Sportradar in the response
+  body, when present.
+
+  The remaining fields contain:
+
+    * `headers` — response headers, including values such as `retry-after`
+    * `body` — a decoded XML/JSON body when possible, otherwise the raw body
+    * `reason` — the underlying transport or decoding failure
+    * `message` — a human-readable error summary
+  """
+
+  @type error_type :: :http | :transport | :decode
+
+  @type t :: %__MODULE__{
+          type: error_type(),
+          status: non_neg_integer() | nil,
+          response_code: String.t() | nil,
+          headers: map(),
+          body: term(),
+          reason: term(),
+          message: String.t()
+        }
+
+  defexception type: nil,
+               status: nil,
+               response_code: nil,
+               headers: %{},
+               body: nil,
+               reason: nil,
+               message: "UOF API request failed"
+end

--- a/lib/uof/api/probability.ex
+++ b/lib/uof/api/probability.ex
@@ -10,6 +10,8 @@ defmodule UOF.API.Probability do
 
   For a fixture to be available in the Probability API, the fixture must be
   active in `Live Odds` and you must have `Live Odds` access to this fixture.
+
+  Functions return `{:ok, response} | {:error, UOF.API.Error.t()}`.
   """
   alias UOF.API.Utils.HTTP
 

--- a/lib/uof/api/recovery.ex
+++ b/lib/uof/api/recovery.ex
@@ -4,9 +4,12 @@ defmodule UOF.API.Recovery do
 
   Recovery requests are issued per `product` — the producer's path segment, such
   as `"liveodds"`, `"pre"` or `"ctrl"` (see `UOF.API.Descriptions.producers/0`).
-  The HTTP response is only an acknowledgement (`UOF.Schemas.Common.Response`);
-  the recovered messages themselves are delivered over the AMQP feed and the
-  sequence ends with a `snapshot_complete` message correlated by `request_id`.
+  The HTTP response is only an acknowledgement and may have no body (`nil`) or
+  contain an `UOF.Schemas.Common.Response`; the recovered messages themselves
+  are delivered over the AMQP feed and the sequence ends with a
+  `snapshot_complete` message correlated by `request_id`.
+
+  Functions return `{:ok, response_or_nil} | {:error, UOF.API.Error.t()}`.
 
   Common options:
 

--- a/lib/uof/api/sports.ex
+++ b/lib/uof/api/sports.ex
@@ -7,7 +7,7 @@ defmodule UOF.API.Sports do
   sport-event summaries and timelines, the sport/category/tournament/season
   catalogue, and player/competitor/venue profiles.
 
-  Every function returns `{:ok, struct} | {:error, Ecto.Changeset.t()}`, where
+  Every function returns `{:ok, struct} | {:error, UOF.API.Error.t()}`, where
   the struct is an `UOF.Schemas.API.Sports.*` embedded schema, and takes an
   optional `lang` (ISO code, default `"en"`).
 

--- a/lib/uof/api/sports/fixtures.ex
+++ b/lib/uof/api/sports/fixtures.ex
@@ -17,6 +17,8 @@ defmodule UOF.API.Sports.Fixtures do
   `Stream`/`Enum` and supports early termination:
 
       Sports.Fixtures.stream() |> Stream.map(& &1.id) |> Enum.take(50)
+
+  API errors are raised when the stream is enumerated.
   """
   def stream(lang \\ "en") do
     Stream.resource(
@@ -25,6 +27,7 @@ defmodule UOF.API.Sports.Fixtures do
         case Sports.pre_schedule(start, @page_size, lang) do
           {:ok, %{sport_event: []}} -> {:halt, start}
           {:ok, %{sport_event: events}} -> {events, start + @page_size}
+          {:error, error} -> raise error
         end
       end,
       fn _ -> :ok end

--- a/lib/uof/api/users.ex
+++ b/lib/uof/api/users.ex
@@ -1,6 +1,8 @@
 defmodule UOF.API.Users do
   @moduledoc """
   API used for administrative purposes.
+
+  Functions return `{:ok, response} | {:error, UOF.API.Error.t()}`.
   """
   alias UOF.API.Utils.HTTP
 

--- a/lib/uof/api/utils/http.ex
+++ b/lib/uof/api/utils/http.ex
@@ -1,16 +1,18 @@
 defmodule UOF.API.Utils.HTTP do
   @moduledoc false
 
+  alias UOF.API.Error
+
   def get(path, params \\ []) do
     client()
-    |> Req.get!(url: Enum.join(path, "/"), params: params)
-    |> decode()
+    |> Req.get(url: Enum.join(path, "/"), params: params)
+    |> handle_response()
   end
 
   def post(path, body \\ "", params \\ []) do
     client()
-    |> Req.post!(url: Enum.join(path, "/"), params: params, body: body)
-    |> decode()
+    |> Req.post(url: Enum.join(path, "/"), params: params, body: body)
+    |> handle_response()
   end
 
   defp client do
@@ -24,9 +26,111 @@ defmodule UOF.API.Utils.HTTP do
     )
   end
 
-  # Every endpoint is polymorphic on its XML root element (a season request to the
-  # fixture endpoint returns <tournament_info>, any endpoint may return the shared
-  # <response> error envelope), so dispatch on the root via decode/1 rather than
-  # asserting a fixed schema.
-  defp decode(%Req.Response{body: body}), do: UOF.Schemas.XML.decode(body)
+  # Classify the HTTP status before decoding: successful endpoints are polymorphic
+  # on their XML root element, while errors may be XML, JSON, HTML, or empty.
+  defp handle_response({:ok, %Req.Response{status: status} = response})
+       when status in 200..299 do
+    decode_success(response)
+  end
+
+  defp handle_response({:ok, %Req.Response{} = response}) do
+    {:error, http_error(response)}
+  end
+
+  defp handle_response({:error, reason}) do
+    {:error,
+     %Error{
+       type: :transport,
+       reason: reason,
+       message: "UOF API transport error: #{format_reason(reason)}"
+     }}
+  end
+
+  defp decode_success(%Req.Response{body: body}) when body in [nil, ""], do: {:ok, nil}
+
+  defp decode_success(%Req.Response{body: body} = response) when is_binary(body) do
+    if String.trim(body) == "" do
+      {:ok, nil}
+    else
+      decode_xml(response)
+    end
+  end
+
+  defp decode_success(%Req.Response{} = response) do
+    {:error, decode_error(response, {:unexpected_body, response.body})}
+  end
+
+  defp decode_xml(%Req.Response{body: body} = response) do
+    case UOF.Schemas.XML.decode(body) do
+      {:ok, decoded} -> {:ok, decoded}
+      {:error, reason} -> {:error, decode_error(response, reason)}
+    end
+  rescue
+    exception -> {:error, decode_error(response, exception)}
+  end
+
+  defp http_error(%Req.Response{} = response) do
+    body = decode_error_body(response.body)
+    response_code = body_value(body, :response_code)
+    detail = body_value(body, :message) || body_value(body, :errors)
+
+    %Error{
+      type: :http,
+      status: response.status,
+      response_code: response_code,
+      headers: response.headers,
+      body: body,
+      message: http_error_message(response.status, response_code, detail)
+    }
+  end
+
+  defp decode_error_body(body) when body in [nil, ""], do: body
+
+  defp decode_error_body(body) when is_binary(body) do
+    if String.trim(body) == "" do
+      body
+    else
+      case UOF.Schemas.XML.decode(body) do
+        {:ok, decoded} -> decoded
+        {:error, _reason} -> body
+      end
+    end
+  rescue
+    _exception -> body
+  end
+
+  defp decode_error_body(body), do: body
+
+  defp decode_error(%Req.Response{} = response, reason) do
+    %Error{
+      type: :decode,
+      status: response.status,
+      headers: response.headers,
+      body: response.body,
+      reason: reason,
+      message: "Unable to decode UOF API response: #{format_reason(reason)}"
+    }
+  end
+
+  defp body_value(body, key) when is_map(body) do
+    Map.get(body, key) || Map.get(body, Atom.to_string(key))
+  end
+
+  defp body_value(_body, _key), do: nil
+
+  defp http_error_message(status, response_code, detail) do
+    suffix = detail || response_code
+
+    if suffix do
+      "UOF API returned HTTP #{status}: #{format_detail(suffix)}"
+    else
+      "UOF API returned HTTP #{status}"
+    end
+  end
+
+  defp format_detail(detail) when is_binary(detail), do: detail
+  defp format_detail(detail), do: inspect(detail)
+
+  defp format_reason(%{__exception__: true} = exception), do: Exception.message(exception)
+  defp format_reason(reason), do: inspect(reason)
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -3,5 +3,6 @@ Application.put_env(:junit_formatter, :report_file, "junit.xml")
 Application.put_env(:junit_formatter, :automatic_create_dir?, true)
 
 Mimic.copy(UOF.API.Utils.HTTP)
+Mimic.copy(Req)
 
 ExUnit.start(formatters: [JUnitFormatter, ExUnit.CLIFormatter])

--- a/test/uof/api/sports_test.exs
+++ b/test/uof/api/sports_test.exs
@@ -201,6 +201,16 @@ defmodule UOF.API.Sports.Test do
              ["sr:match:1", "sr:match:2", "sr:match:3", "sr:match:4"]
   end
 
+  test "stream/0 raises API errors while enumerating" do
+    error = %UOF.API.Error{type: :http, status: 503, message: "UOF API returned HTTP 503"}
+
+    stub(UOF.API.Utils.HTTP, :get, fn _endpoint, _params -> {:error, error} end)
+
+    assert_raise UOF.API.Error, "UOF API returned HTTP 503", fn ->
+      UOF.API.Sports.Fixtures.stream() |> Enum.to_list()
+    end
+  end
+
   test "filters a schedule by liveodds booking state" do
     {:ok, schedule} =
       UOF.Schemas.XML.decode(

--- a/test/uof/api/utils/http_test.exs
+++ b/test/uof/api/utils/http_test.exs
@@ -1,0 +1,112 @@
+defmodule UOF.API.Utils.HTTP.Test do
+  use ExUnit.Case
+  use Mimic
+
+  alias UOF.API.Error
+  alias UOF.API.Utils.HTTP
+
+  setup do
+    Application.put_env(:uof_api, :base_url, "https://example.test/v1")
+    Application.put_env(:uof_api, :auth_token, "token")
+
+    on_exit(fn ->
+      Application.delete_env(:uof_api, :base_url)
+      Application.delete_env(:uof_api, :auth_token)
+    end)
+
+    :ok
+  end
+
+  test "decodes a successful XML response" do
+    expect(Req, :get, fn _request, _options ->
+      {:ok,
+       Req.Response.new(
+         status: 200,
+         body: ~s(<response response_code="OK"><message>Ready</message></response>)
+       )}
+    end)
+
+    assert {:ok, response} = HTTP.get(["status.xml"])
+    assert response.response_code == "OK"
+    assert response.message == "Ready"
+  end
+
+  test "accepts an empty response for any successful HTTP status" do
+    expect(Req, :post, fn _request, _options ->
+      {:ok, Req.Response.new(status: 202, body: "")}
+    end)
+
+    assert {:ok, nil} = HTTP.post(["liveodds", "recovery", "initiate_request"])
+  end
+
+  test "returns a structured error for an XML HTTP error" do
+    expect(Req, :get, fn _request, _options ->
+      {:ok,
+       Req.Response.new(
+         status: 404,
+         body:
+           ~s(<response response_code="NOT_FOUND"><message>No data for event</message></response>)
+       )}
+    end)
+
+    assert {:error, %Error{} = error} = HTTP.get(["missing.xml"])
+    assert error.type == :http
+    assert error.status == 404
+    assert error.response_code == "NOT_FOUND"
+    assert error.message == "UOF API returned HTTP 404: No data for event"
+    assert error.body.message == "No data for event"
+  end
+
+  test "preserves decoded JSON error bodies and response headers" do
+    expect(Req, :get, fn _request, _options ->
+      {:ok,
+       Req.Response.new(
+         status: 429,
+         headers: [{"retry-after", "5"}],
+         body: %{"message" => "Rate limit reached"}
+       )}
+    end)
+
+    assert {:error, %Error{} = error} = HTTP.get(["probabilities", "sr:match:1"])
+    assert error.status == 429
+    assert error.headers["retry-after"] == ["5"]
+    assert error.body == %{"message" => "Rate limit reached"}
+    assert error.message == "UOF API returned HTTP 429: Rate limit reached"
+  end
+
+  test "preserves non-XML error bodies" do
+    html = "<html><h1>503 Service Unavailable</h1></html>"
+
+    expect(Req, :get, fn _request, _options ->
+      {:ok, Req.Response.new(status: 503, body: html)}
+    end)
+
+    assert {:error, %Error{} = error} = HTTP.get(["sports.xml"])
+    assert error.status == 503
+    assert error.body == html
+    assert error.message == "UOF API returned HTTP 503"
+  end
+
+  test "returns transport failures instead of raising" do
+    expect(Req, :get, fn _request, _options ->
+      {:error, %RuntimeError{message: "connection closed"}}
+    end)
+
+    assert {:error, %Error{} = error} = HTTP.get(["sports.xml"])
+    assert error.type == :transport
+    assert error.status == nil
+    assert error.message == "UOF API transport error: connection closed"
+  end
+
+  test "returns decoding failures instead of raising" do
+    expect(Req, :get, fn _request, _options ->
+      {:ok, Req.Response.new(status: 200, body: "not XML")}
+    end)
+
+    assert {:error, %Error{} = error} = HTTP.get(["sports.xml"])
+    assert error.type == :decode
+    assert error.status == 200
+    assert error.body == "not XML"
+    assert error.reason
+  end
+end

--- a/test/uof_api_test.exs
+++ b/test/uof_api_test.exs
@@ -1,5 +1,0 @@
-defmodule UOF.API.Test do
-  use ExUnit.Case
-
-  # TO-DO: test {:ok, _resp} | {:error, _error} contract
-end


### PR DESCRIPTION
### Description

Return `UOF.API.Error` for HTTP, transport, and decoding failures. Accept empty `2xx` responses and preserve status, headers, and error bodies.

This is a **breaking change** because API failures no longer return decoded success values or raise transport exceptions; they now return `{:error, %UOF.API.Error{}}`.