### PR TITLE
feat: add support for including mappings with market descriptions

### DIFF
--- a/lib/uof/api/descriptions.ex
+++ b/lib/uof/api/descriptions.ex
@@ -17,12 +17,14 @@ defmodule UOF.API.Descriptions do
 
   @doc """
   Describe all currently available markets.
+
+  Pass `include_mappings: true` to also include each market's mappings to
+  provider-specific market/outcome ids.
   """
-  def markets(lang \\ "en", opts \\ []) do
-    # TO-DO: Optional mappings
+  def markets(lang \\ "en", include_mappings \\ false, opts \\ []) do
     endpoint = ["descriptions", lang, "markets.xml"]
 
-    HTTP.get(endpoint, [], opts)
+    HTTP.get(endpoint, [include_mappings: include_mappings], opts)
   end
 
   @doc """

--- a/test/uof/api/descriptions_test.exs
+++ b/test/uof/api/descriptions_test.exs
@@ -3,11 +3,13 @@ defmodule UOF.API.Descriptions.Test do
   use Mimic
 
   alias UOF.API.Descriptions
+  alias UOF.API.Utils.HTTP
+  alias UOF.Schemas.XML
 
   setup do
-    stub(UOF.API.Utils.HTTP, :get, fn endpoint, _params, _opts ->
+    stub(HTTP, :get, fn endpoint, _params, _opts ->
       data = File.read!("test/data/" <> Enum.at(endpoint, -1))
-      UOF.Schemas.XML.decode(data)
+      XML.decode(data)
     end)
 
     :ok
@@ -23,6 +25,16 @@ defmodule UOF.API.Descriptions.Test do
     assert market.name == "Innings 1 to 5th top - {$competitor1} total"
     assert market.groups == "all|score|4.5_innings"
     assert Enum.map(market.outcomes.outcome, & &1.id) == ["13", "12"]
+  end
+
+  test "markets/2 passes include_mappings through as a query param" do
+    expect(HTTP, :get, fn endpoint, params, _opts ->
+      data = File.read!("test/data/" <> Enum.at(endpoint, -1))
+      assert params == [include_mappings: true]
+      XML.decode(data)
+    end)
+
+    Descriptions.markets("en", true)
   end
 
   test "can parse UOF.API.Descriptions.match_statuses/{0, 1} response" do


### PR DESCRIPTION
### Description

Extend `UOF.API.Descriptions.market` with an optional `include_mappings` parameter (defaults to `false`) to include market mappings in the HTTP response.

See [official documentation](https://docs.sportradar.com/uof/data-and-features/markets-and-outcomes/market-mapping) for more details.