### PR TITLE
feat: extend UOF.API.Sports.fixture_changes with after and sport filters

### DIFF
--- a/lib/uof/api/sports.ex
+++ b/lib/uof/api/sports.ex
@@ -65,23 +65,42 @@ defmodule UOF.API.Sports do
   end
 
   @doc """
-  Get a list of all the fixtures that have changed in the last 24 hours.
+  Get a list of all the fixtures that have changed.
+
+  Defaults to changes in the last 24 hours. Pass `filters` to narrow the
+  results:
+
+    * `:after` - only return changes after this point in time (a `DateTime`,
+      `NaiveDateTime`, or an already-formatted ISO8601 string). Use this to
+      catch up on changes missed during downtime longer than 24 hours.
+    * `:sport` - only return changes for the given sport urn (e.g.
+      `"sr:sport:1"`).
   """
-  def fixture_changes(lang \\ "en", opts \\ []) do
-    # TO-DO: add support for 'after datetime' and 'sport' filters
+  def fixture_changes(lang \\ "en", filters \\ [], opts \\ []) do
     endpoint = ["sports", lang, "fixtures", "changes.xml"]
 
-    HTTP.get(endpoint, [], opts)
+    HTTP.get(endpoint, changes_params(filters), opts)
   end
 
   @doc """
-  Get a lists of all the fixtures that have changed results in the last 24 hours.
+  Get a lists of all the fixtures that have changed results.
+
+  Same optional `filters` as `fixture_changes/3`.
   """
-  def result_changes(lang \\ "en", opts \\ []) do
-    # TO-DO: add support for 'after datetime' and 'sport' filters
+  def result_changes(lang \\ "en", filters \\ [], opts \\ []) do
     endpoint = ["sports", lang, "results", "changes.xml"]
 
-    HTTP.get(endpoint, [], opts)
+    HTTP.get(endpoint, changes_params(filters), opts)
+  end
+
+  defp changes_params(filters) do
+    Enum.map(filters, fn
+      {:after, %mod{} = datetime} when mod in [DateTime, NaiveDateTime] ->
+        {:after, mod.to_iso8601(datetime)}
+
+      {key, value} when key in [:after, :sport] ->
+        {key, value}
+    end)
   end
 
   ## Sport Event Information

--- a/test/uof/api/sports_test.exs
+++ b/test/uof/api/sports_test.exs
@@ -176,6 +176,16 @@ defmodule UOF.API.Sports.Test do
     assert change.update_time == ~U[2024-04-26 19:12:43Z]
   end
 
+  test "fixture_changes/2 passes the after/sport filters through as query params" do
+    expect(HTTP, :get, fn endpoint, params, _opts ->
+      {:ok, data} = fetch_mock_data(endpoint)
+      assert params == [after: "2024-04-26T00:00:00Z", sport: "sr:sport:1"]
+      XML.decode(data)
+    end)
+
+    Sports.fixture_changes("en", after: ~U[2024-04-26 00:00:00Z], sport: "sr:sport:1")
+  end
+
   test "can parse UOF.API.Sports.result_changes/{0, 1} response" do
     {:ok, data} = Sports.result_changes()
 
@@ -184,6 +194,16 @@ defmodule UOF.API.Sports.Test do
     assert Enum.count(data.result_change) == 4236
     assert change.sport_event_id == "sr:match:49689671"
     assert change.update_time == ~U[2024-04-26 19:12:56Z]
+  end
+
+  test "result_changes/2 passes the after/sport filters through as query params" do
+    expect(HTTP, :get, fn endpoint, params, _opts ->
+      {:ok, data} = fetch_mock_data(endpoint)
+      assert params == [after: "2024-04-26T00:00:00Z", sport: "sr:sport:1"]
+      XML.decode(data)
+    end)
+
+    Sports.result_changes("en", after: ~U[2024-04-26 00:00:00Z], sport: "sr:sport:1")
   end
 
   test "stream/0 paginates the prematch schedule and aggregates events" do


### PR DESCRIPTION
### Description

Extend `UOF.API.Sports.{fixture, result}_changes` with `after` and `sport` filters.

More information in the official documentation (see [here](https://docs.sportradar.com/uof/api-and-structure/api/static-sport-event-information/fixture-changes-endpoint) and [here](https://docs.sportradar.com/uof/api-and-structure/api/static-sport-event-information/result-changes-endpoint)). 